### PR TITLE
feat: Configure for local LLM deployment with LM Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,109 @@
-# llm-studio
+# Echo AI Assistant
 
-[Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/deskiziarecords/llm-studio)
+Echo AI Assistant is a versatile chat application designed to interact with various AI models, including cloud-based services like OpenAI and Anthropic, as well as locally hosted language models. It features voice input/output capabilities and a customizable interface.
+
+## Features
+
+*   **Multi-Provider Support**: Connect to OpenAI, Anthropic, and local OpenAI-compatible AI models.
+*   **Chat Interface**: Modern and intuitive interface for seamless conversations.
+*   **Voice Input/Output**: Use your voice to interact with the AI (Speech-to-Text and Text-to-Speech).
+*   **Customizable Settings**: Configure API keys, voice preferences, appearance (themes, font sizes), and model parameters.
+*   **Local Model Focus**: Pre-configured to easily connect to local LLM servers like LM Studio.
+*   **Markdown Rendering**: Support for markdown in AI responses.
+*   **Responsive Design**: Works across different screen sizes.
+
+## Getting Started
+
+### Prerequisites
+
+*   Node.js (version 18.x or later recommended)
+*   npm or yarn
+
+### Installation & Running Locally
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/deskiziarecords/llm-studio.git
+    cd llm-studio
+    ```
+
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    # or
+    yarn install
+    ```
+
+3.  **Run the development server:**
+    ```bash
+    npm run dev
+    # or
+    yarn dev
+    ```
+    This will start the application, typically on `http://localhost:5173`.
+
+4.  **Open in browser:** Navigate to the local URL provided in your terminal.
+
+## Using with a Local LLM Server (LM Studio Example)
+
+This application is designed to work with local Large Language Models (LLMs) that expose an OpenAI-compatible API endpoint. LM Studio is a popular tool that allows you to download, run, and serve various open-source models locally.
+
+### 1. LM Studio Setup
+
+*   **Download and Install**: If you haven't already, download and install [LM Studio](https://lmstudio.ai/) for your operating system.
+*   **Download a Model**: Within LM Studio, search for and download a model you wish to use (e.g., a GGUF version of Mistral, Llama, etc.).
+*   **Start the AI Model Server**:
+    *   Navigate to the "Server" tab (often represented by an icon like `<-->`).
+    *   Select the model you downloaded from the dropdown.
+    *   Click "Start Server".
+    *   By default, LM Studio starts the server at `http://localhost:1234/v1`. Note this address.
+
+### 2. Application Configuration
+
+*   **Pre-configured for LM Studio**: Echo AI Assistant comes pre-configured with a default model setting for "LM Studio (Local)".
+*   **Default Endpoint**: This default configuration in the application targets `http://localhost:1234/v1`, which is the standard for LM Studio.
+    *   If your LM Studio server is running on a different port or path, you can select the "LM Studio (Local)" model. The application will use its default. If you need to specify a *different* custom endpoint for the "LM Studio (Local)" entry beyond the application's default for it, you would currently need to modify its `endpoint` field in `src/store/index.ts`.
+*   **Select the Model**:
+    *   In the Echo AI Assistant application, click on the model selector (usually at the top or side of the chat interface).
+    *   Choose "LM Studio (Local)" from the list of available models. The application is set to use this model by default on first launch.
+*   **No API Key Needed**: For this local setup, API keys are not required. The API key input fields in the Settings page will be hidden or indicate they are not necessary when a local model is active.
+
+### 3. Start Chatting!
+
+Once your local LM Studio server is running and the "LM Studio (Local)" model is selected in the application, you can start chatting with your local LLM.
+
+### Troubleshooting & Notes
+
+*   **Server Must Be Running**: Ensure your LM Studio (or other local LLM) server is active and serving the model.
+*   **Performance**: The speed and performance of responses from local models depend heavily on your computer's hardware (CPU, RAM, and GPU if applicable for the model).
+*   **CORS Issues**: Most local server tools like LM Studio are configured to allow requests from local web applications (like this one running on `localhost:5173`). If you encounter connection problems, check the console output from your local LLM server for any Cross-Origin Resource Sharing (CORS) errors and adjust its settings if necessary.
+*   **Model Compatibility**: Ensure the model you are serving is compatible with the OpenAI chat completions API format. Most models served via LM Studio aim for this compatibility.
+
+## Configuration for Cloud Models
+
+If you wish to use cloud-based models:
+
+1.  Navigate to the **Settings** page within the application.
+2.  Select a cloud model (e.g., GPT-3.5 Turbo, Claude 3 Opus) from the model selector.
+3.  Enter your API key for the respective provider (e.g., OpenAI, Anthropic) in the API Keys section.
+4.  Save your settings.
+
+## Contributing
+
+Contributions are welcome! If you have suggestions, bug reports, or want to contribute code, please feel free to:
+
+1.  Fork the repository.
+2.  Create a new branch (`git checkout -b feature/YourFeature` or `bugfix/YourBugfix`).
+3.  Make your changes.
+4.  Commit your changes (`git commit -m 'Add some feature'`).
+5.  Push to the branch (`git push origin feature/YourFeature`).
+6.  Open a Pull Request.
+
+## License
+
+This project is licensed under the MIT License. (A `LICENSE` file should be created and added to the repository).
+
+---
+
+*Powered by Vite, React, TypeScript, and Tailwind CSS.*
+(The StackBlitz link can be re-added if desired, but keeping it minimal for now)

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -1,0 +1,30 @@
+interface Settings {
+  selectedModel: string;
+  apiKeyOpenAI: string;
+  apiKeyAnthropic: string;
+  voiceEnabled: boolean;
+  selectedVoice: string;
+  theme: 'light' | 'dark' | 'system';
+}
+
+export const loadSettings = (): Settings | null => {
+  try {
+    const serializedSettings = localStorage.getItem('appSettings');
+    if (serializedSettings === null) {
+      return null;
+    }
+    return JSON.parse(serializedSettings);
+  } catch (error) {
+    console.error('Error loading settings from localStorage:', error);
+    return null;
+  }
+};
+
+export const saveSettings = (settings: Settings): void => {
+  try {
+    const serializedSettings = JSON.stringify(settings);
+    localStorage.setItem('appSettings', serializedSettings);
+  } catch (error) {
+    console.error('Error saving settings to localStorage:', error);
+  }
+};

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,13 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useStore } from '../store';
-import { AppSettings } from '../types';
+import { AppSettings, ModelConfig } from '../types';
 import { motion } from 'framer-motion';
 import { Save, Key, Volume2, PaintBucket, Sliders } from 'lucide-react';
 
 export const SettingsPage: React.FC = () => {
-  const { settings, updateSettings } = useStore();
-  const [localSettings, setLocalSettings] = useState<AppSettings>({ ...settings });
+  const { settings, updateSettings, currentModel } = useStore();
+  const [localSettings, setLocalSettings] = useState<AppSettings>(settings);
   const [savedMessage, setSavedMessage] = useState(false);
+
+  // Effect to update localSettings if global settings change from elsewhere
+  // or if the settings from the store are loaded after initial component mount.
+  useEffect(() => {
+    setLocalSettings(settings);
+  }, [settings]);
   
   const handleSave = () => {
     updateSettings(localSettings);
@@ -70,28 +76,35 @@ export const SettingsPage: React.FC = () => {
       <div className="space-y-8">
         {/* API Keys */}
         <SettingsSection title="API Keys" icon={<Key className="text-primary-400" />}>
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm text-gray-400 mb-1">OpenAI API Key</label>
-              <input
-                type="password"
-                value={localSettings.apiKeys['openai'] || ''}
-                onChange={(e) => updateApiKey('openai', e.target.value)}
-                placeholder="sk-..."
-                className="w-full bg-dark-700 border border-dark-600 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500/50"
-              />
+          {currentModel && currentModel.type === 'local' ? (
+            <div className="p-4 text-sm text-gray-400 bg-dark-700 rounded-lg">
+              API keys are not required for the selected local model ({currentModel.name}).
             </div>
-            <div>
-              <label className="block text-sm text-gray-400 mb-1">Anthropic API Key</label>
-              <input
-                type="password"
-                value={localSettings.apiKeys['anthropic'] || ''}
-                onChange={(e) => updateApiKey('anthropic', e.target.value)}
-                placeholder="sk-ant-..."
-                className="w-full bg-dark-700 border border-dark-600 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500/50"
-              />
+          ) : (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">OpenAI API Key</label>
+                <input
+                  type="password"
+                  value={localSettings.apiKeys['openai'] || ''}
+                  onChange={(e) => updateApiKey('openai', e.target.value)}
+                  placeholder="sk-..."
+                  className="w-full bg-dark-700 border border-dark-600 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500/50"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Anthropic API Key</label>
+                <input
+                  type="password"
+                  value={localSettings.apiKeys['anthropic'] || ''}
+                  onChange={(e) => updateApiKey('anthropic', e.target.value)}
+                  placeholder="sk-ant-..."
+                  className="w-full bg-dark-700 border border-dark-600 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500/50"
+                />
+              </div>
+              {/* Add other API key inputs here if needed, e.g., for other cloud providers */}
             </div>
-          </div>
+          )}
         </SettingsSection>
         
         {/* Voice Settings */}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -32,9 +32,11 @@ interface ChatCompletionResponse {
 }
 
 export interface ApiConfig {
-  apiKey: string;
-  baseUrl?: string;
+  apiKey: string; // Used for cloud providers
+  baseUrl?: string; // Can be used to override base URLs for any provider if needed
 }
+
+const LOCAL_MODEL_DEFAULT_BASE_URL = 'http://localhost:1234/v1';
 
 /**
  * Send a chat completion request to the selected model
@@ -47,44 +49,46 @@ export async function sendChatCompletion(
   try {
     // Determine the API endpoint based on model provider
     let endpoint: string;
-    let headers: Record<string, string> = {};
-    
-    switch (modelConfig.provider) {
-      case 'openai':
-        endpoint = 'https://api.openai.com/v1/chat/completions';
-        headers = {
-          'Authorization': `Bearer ${apiConfig.apiKey}`,
-        };
-        break;
-      case 'anthropic':
-        endpoint = 'https://api.anthropic.com/v1/messages';
-        headers = {
-          'x-api-key': apiConfig.apiKey,
-          'anthropic-version': '2023-06-01',
-        };
-        // Transform request format for Anthropic API
-        const anthropicRequest = {
-          model: request.model,
-          messages: request.messages,
-          max_tokens: request.max_tokens,
-        };
-        return sendRequest(endpoint, anthropicRequest, headers);
-      case 'mistral':
-      case 'meta':
-      case 'other':
-        // For local models, use the custom endpoint
-        if (modelConfig.type === 'local' && modelConfig.endpoint) {
-          endpoint = modelConfig.endpoint;
-          // Local models typically don't need authentication
-          return sendRequest(endpoint, request, headers);
-        } else {
-          throw new Error(`No endpoint defined for ${modelConfig.name}`);
-        }
-      default:
-        throw new Error(`Unsupported provider: ${modelConfig.provider}`);
+    let headers: Record<string, string> = { 'Content-Type': 'application/json' }; // Default content type
+    let requestBody = request;
+
+    if (modelConfig.type === 'local') {
+      const baseUrl = modelConfig.endpoint || apiConfig.baseUrl || LOCAL_MODEL_DEFAULT_BASE_URL;
+      endpoint = `${baseUrl.replace(/\/$/, '')}/chat/completions`;
+      // No specific auth headers for local models by default
+    } else {
+      switch (modelConfig.provider) {
+        case 'openai':
+          endpoint = apiConfig.baseUrl || 'https://api.openai.com/v1/chat/completions';
+          headers['Authorization'] = `Bearer ${apiConfig.apiKey}`;
+          break;
+        case 'anthropic':
+          endpoint = apiConfig.baseUrl || 'https://api.anthropic.com/v1/messages';
+          headers['x-api-key'] = apiConfig.apiKey;
+          headers['anthropic-version'] = '2023-06-01';
+          // Transform request format for Anthropic API
+          requestBody = {
+            model: request.model,
+            messages: request.messages,
+            max_tokens: request.max_tokens,
+            // stream: false, // Anthropic uses Accept header for streaming, not body property
+          } as any; // Cast to any to avoid type conflict, proper type would be better
+          break;
+        default:
+          // This case handles 'mistral', 'meta', 'other' if they are not type 'local'
+          // It assumes they behave like OpenAI or require a specific 'baseUrl' in ApiConfig
+          if (apiConfig.baseUrl) {
+            endpoint = `${apiConfig.baseUrl.replace(/\/$/, '')}/chat/completions`;
+            if (apiConfig.apiKey) { // Add auth if API key is provided
+              headers['Authorization'] = `Bearer ${apiConfig.apiKey}`;
+            }
+          } else {
+            throw new Error(`Unsupported cloud provider or missing baseUrl: ${modelConfig.provider}`);
+          }
+      }
     }
     
-    return sendRequest(endpoint, request, headers);
+    return sendRequest(endpoint, requestBody, headers);
   } catch (error) {
     console.error('Error sending chat completion:', error);
     throw error;
@@ -117,40 +121,53 @@ export async function streamChatCompletion(
     
     // Determine the API endpoint based on model provider
     let endpoint: string;
-    let headers: Record<string, string> = {};
-    
-    switch (modelConfig.provider) {
-      case 'openai':
-        endpoint = 'https://api.openai.com/v1/chat/completions';
-        headers = {
-          'Authorization': `Bearer ${apiConfig.apiKey}`,
-          'Content-Type': 'application/json',
-          'Accept': 'text/event-stream',
-        };
-        break;
-      case 'anthropic':
-        endpoint = 'https://api.anthropic.com/v1/messages';
-        headers = {
-          'x-api-key': apiConfig.apiKey,
-          'anthropic-version': '2023-06-01',
-          'Content-Type': 'application/json',
-          'Accept': 'text/event-stream',
-        };
-        break;
-      default:
-        // For local models or other providers
-        if (modelConfig.type === 'local' && modelConfig.endpoint) {
-          endpoint = modelConfig.endpoint;
-        } else {
-          throw new Error(`Streaming not supported for ${modelConfig.provider}`);
-        }
+    let headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Accept': 'text/event-stream'
+    };
+    let requestBody = { ...request, stream: true }; // Ensure stream is true for all providers if not set
+
+    if (modelConfig.type === 'local') {
+      const baseUrl = modelConfig.endpoint || apiConfig.baseUrl || LOCAL_MODEL_DEFAULT_BASE_URL;
+      endpoint = `${baseUrl.replace(/\/$/, '')}/chat/completions`;
+      // No specific auth headers for local models by default for streaming
+    } else {
+      switch (modelConfig.provider) {
+        case 'openai':
+          endpoint = apiConfig.baseUrl || 'https://api.openai.com/v1/chat/completions';
+          headers['Authorization'] = `Bearer ${apiConfig.apiKey}`;
+          break;
+        case 'anthropic':
+          endpoint = apiConfig.baseUrl || 'https://api.anthropic.com/v1/messages';
+          headers['x-api-key'] = apiConfig.apiKey;
+          headers['anthropic-version'] = '2023-06-01';
+          // Anthropic specific: stream parameter might be in the body or handled by Accept header
+          // For this example, keeping requestBody similar to OpenAI for stream=true
+          requestBody = {
+            ...request,
+            stream: true,
+            // Anthropic specific body for streaming if different from non-streaming
+            // messages: request.messages, model: request.model, max_tokens: request.max_tokens etc.
+          } as any;
+          break;
+        default:
+          // This case handles 'mistral', 'meta', 'other' if they are not type 'local'
+          if (apiConfig.baseUrl) {
+            endpoint = `${apiConfig.baseUrl.replace(/\/$/, '')}/chat/completions`;
+             if (apiConfig.apiKey) { // Add auth if API key is provided
+              headers['Authorization'] = `Bearer ${apiConfig.apiKey}`;
+            }
+          } else {
+            throw new Error(`Streaming not supported or missing baseUrl for cloud provider: ${modelConfig.provider}`);
+          }
+      }
     }
     
     // Use fetch for streaming
     const response = await fetch(endpoint, {
       method: 'POST',
       headers,
-      body: JSON.stringify(request),
+      body: JSON.stringify(requestBody),
     });
     
     if (!response.ok) {
@@ -175,10 +192,28 @@ export async function streamChatCompletion(
       const chunk = decoder.decode(value);
       const lines = chunk.split('\n');
       
+      // This SSE parsing logic is designed for OpenAI-compatible streams.
+      // It assumes:
+      // 1. Data messages start with "data: ".
+      // 2. The payload is a JSON object.
+      // 3. Text content is found in `choices[0].delta.content`.
+      // 4. Stream termination is signaled by a `data: [DONE]` message.
+      // Services like LM Studio are expected to adhere to this format for compatibility.
       for (const line of lines) {
-        if (line.startsWith('data:') && !line.includes('[DONE]')) {
-          try {
-            const jsonData = JSON.parse(line.slice(5));
+        // Skip empty lines and non-data lines
+        if (!line.trim() || !line.startsWith('data:')) {
+          continue;
+        }
+
+        // Handle the [DONE] signal from OpenAI-compatible streams
+        if (line.includes('[DONE]')) {
+          // The loop will break naturally when reader.read() returns done: true.
+          // This check is mostly to prevent trying to parse "[DONE]" as JSON.
+          continue;
+        }
+
+        try {
+          const jsonData = JSON.parse(line.slice(5)); // Remove "data: " prefix
             const content = jsonData.choices[0]?.delta?.content || '';
             if (content) {
               onChunk(content);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,10 +8,17 @@ export interface Message {
 export interface ModelConfig {
   id: string;
   name: string;
-  provider: 'openai' | 'anthropic' | 'mistral' | 'meta' | 'other';
+  provider: 'openai' | 'anthropic' | 'mistral' | 'meta' | 'lmstudio' | 'ollama' | 'other'; // Added lmstudio & ollama as example local providers
   type: 'cloud' | 'local';
-  endpoint?: string;
+  endpoint?: string; // Optional custom endpoint for the model, e.g., for a self-hosted local model
 }
+
+// Note: ApiConfig is defined in src/services/api.ts.
+// For consistency if it were here, it might look like:
+// export interface ApiConfig {
+//   apiKey?: string; // API key is optional, especially for local models
+//   baseUrl?: string;
+// }
 
 export interface AppSettings {
   apiKeys: {


### PR DESCRIPTION
This commit introduces changes to facilitate easier local deployment of your application, specifically targeting local LLM servers like LM Studio that provide an OpenAI-compatible API.

Key changes include:

- **API Service Update**: `services/api.ts` now correctly handles requests to local models by:
    - Using a default local base URL (`http://localhost:1234/v1`) or a model-specific endpoint.
    - Omitting Authorization headers for local model requests.
- **Default Local Model**:
    - Added an "LM Studio (Local)" model configuration to `src/store/index.ts` and set it as the default `currentModel`.
    - Updated `src/types/index.ts` to better support local model configurations (e.g., optional API keys, custom endpoints).
- **Simplified Settings UI**:
    - `src/pages/SettingsPage.tsx` now conditionally hides API key inputs for OpenAI/Anthropic when a local model is selected, displaying a message that keys are not required.
- **Streaming Compatibility**:
    - Reviewed and added clarifications to `services/api.ts` for SSE streaming, assuming OpenAI-compatibility from local servers like LM Studio.
- **Documentation**:
    - Updated `README.md` with a new section explaining how to use the application with LM Studio, including setup and configuration details.

These changes improve the out-of-the-box experience for you when intending to use the application with local LLMs, reducing configuration friction.